### PR TITLE
Add bin/process-schemas-for-redoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ bin/get-schemas-for-redoc
 
 Find the redoc-ready schemas at `__output__`. For debugging, use intermediate results in `__output__/artifacts`.
 
+### Only process the schema
+
+If you already have the  following schemas locally:
+
+- `__output__/artifacts/admin-schema-original.json`
+- `__output__/artifacts/customer-schema-original.json`
+- `__output__/artifacts/guest-schema-original.json`
+
+then you can process them with:
+
+```bash
+bin/process-schemas-for-redoc
+```
+
 ## Running tests
 
 This project uses [Jest][] for tests.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Find the redoc-ready schemas at `__output__`. For debugging, use intermediate re
 
 ### Only process the schema
 
-If you already have the  following schemas locally:
+If you already have the following schemas locally:
 
 - `__output__/artifacts/admin-schema-original.json`
 - `__output__/artifacts/customer-schema-original.json`

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
 convert () {
+  if [ -z "$VERSION" ]; then
+    echo "ERROR: VERSION is not set. Exiting."
+    exit 1
+  fi
+
   ruby -ryaml -rjson -e 'puts JSON.parse(ARGF.read).to_yaml' < __output__/artifacts/admin-schema-edited.json > __output__/admin-schema-$VERSION.yaml
   ruby -ryaml -rjson -e 'puts JSON.parse(ARGF.read).to_yaml' < __output__/artifacts/customer-schema-edited.json > __output__/customer-schema-$VERSION.yaml
   ruby -ryaml -rjson -e 'puts JSON.parse(ARGF.read).to_yaml' < __output__/artifacts/guest-schema-edited.json > __output__/guest-schema-$VERSION.yaml

--- a/bin/get-schemas-for-redoc
+++ b/bin/get-schemas-for-redoc
@@ -54,10 +54,8 @@ echo "Getting REST schema as Guest"
 # Send a GET request and write schema to a file
 curl "$STORE_URL"/rest/default/schema > __output__/artifacts/guest-schema-original.json
 
-# # Check exceptions
+# # Check exceptions for debugging
 # cat /var/www/html/commerce/var/log/exception.log
 
-echo 'Post-processing'
-transform
-edit
-convert
+# Process the schemas
+bin/process-schemas-for-redoc

--- a/bin/process-schemas-for-redoc
+++ b/bin/process-schemas-for-redoc
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+source bin/functions.sh
+
+echo 'Checking if all required files exist...'
+files=(
+  "__output__/artifacts/admin-schema-original.json"
+  "__output__/artifacts/customer-schema-original.json"
+  "__output__/artifacts/guest-schema-original.json"
+)
+
+for file in "${files[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "ERROR: File $file does not exist. Exiting."
+    exit 1
+  fi
+done
+
+echo 'Processing the schemas...'
+transform
+edit
+convert


### PR DESCRIPTION
Adding a separate command to only process the schemas in case they are available locally, without the need to get them from remote servers.

## How to test
1. Checkout this branch
1. Make sure your schemas are located and named as the following:
   - `__output__/artifacts/admin-schema-original.json`
   - `__output__/artifacts/customer-schema-original.json`
   - `__output__/artifacts/guest-schema-original.json`
1. Run the new command from the root dir of the project:
   ```
   bin/process-schemas-for-redoc
   ```